### PR TITLE
fix: 紹介文が存在しない場合のハンドリング処理を追加.

### DIFF
--- a/src/components/Digimons.tsx
+++ b/src/components/Digimons.tsx
@@ -66,7 +66,7 @@ export const Digimons: FC<DigimonsType> = memo(({ randNum }) => {
                     </div>
                     <div className="lg:w-[48%]">
                         {nextEvolutions.length > 0 ?
-                            <div className="flex flex-row flex-wrap gap-[2%] text-sm py-[2.5em] mb-[2.5em] border-b-[#333] border-b-[dotted] md:p-0">
+                            <div className="flex flex-row flex-wrap gap-[2%] text-sm py-[2.5em] mb-[2.5em] border-b-1 border-b-[#333] border-dotted md:p-0">
                                 <h3 className="w-full text-base mb-[0.5em]">あなたの将来性<span className="block text-sm leading-[1.2]">（※進化後）</span></h3>
                                 <>
                                     {nextEvolutions.map((evolution, i) => (

--- a/src/hooks/useSetDigimonItems.ts
+++ b/src/hooks/useSetDigimonItems.ts
@@ -12,10 +12,14 @@ export const useSetDigimonItems = () => {
         fetchDigiData.then((data) => {
             setDigimonData(data);
 
+            if (data?.descriptions.length === 0) {
+                setDescriptions('このデジモンには紹介文はありません。');
+            }
+
             /* デジモンの紹介文（日本語）*/
             data?.descriptions.forEach(digiDescriptionData => {
-                if (digiDescriptionData.language === 'jap') {
-                    setDescriptions(digiDescriptionData.description)
+                if (digiDescriptionData.language === 'jap' && digiDescriptionData.description.length > 0) {
+                    setDescriptions(digiDescriptionData.description);
                 }
             });
 

--- a/src/ts/digimon.ts
+++ b/src/ts/digimon.ts
@@ -21,7 +21,8 @@ export type digimons = {
         forEach(arg0: (data: {
             language: string;
             description: string;
-        }) => void): string[]
+        }) => void): string[],
+        length: number;
     };
     images: {
         [0]: {


### PR DESCRIPTION
- 紹介文が存在しない場合のハンドリング処理を追加
  - `src/components/Digimons.tsx`<br>Tailwind CSS のスタイリング記述ミスの修正
  - `src/hooks/useSetDigimonItems.ts`<br>紹介文が存在しない場合はその旨を表示
  - `src/ts/digimon.ts`<br>型注釈の修正